### PR TITLE
Feature: Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mkdocs-data-plugin
 __MkDocs Data Plugin__ is a plugin for [MkDocs](https://www.mkdocs.org/) that allows
-reading data from separate external markup files and use it in your Markdown pages.
+reading data from markup files and use it in your Markdown pages.
 
 Currently supported formats:
 
@@ -28,7 +28,7 @@ plugins:
 
 ## Overview
 When using this plugin, you can define data in YAML or JSON files
-in a separate directory and reference it in your Markdown files.
+in a separate directory and reference them in your Markdown files.
 
 ```txt
 root/

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2,18 +2,26 @@
 
 This plugin provides the following configuration options.
 
-## Data Directory
-The `data_dir` option specifies the directory where data files are stored. By default, this is set to `data`.
+## Data Sources
+The `sources` option is a dictionary that defines the data sources to be used.
+Each key-value pair represents a source name and its corresponding directory path.
+
+A source can reference directories or files.
+If a directory is specified, all files in the directory and its subdirectories will be loaded.
+
+By default, a single data source named `data` is defined with the directory path `data`.
 
 ```yaml
 plugins:
-  - data:
-      data_dir: data
+  - sources:
+      data: data # default
+      foo: docs/foo.yml
 ```
 
 !!! tip
     It is recommended to configure the `watch` option in the `mkdocs.yml` file
-    to automatically reload the site when data files are modified.
+    to automatically reload the site when files in the data sources outside
+    the `docs` directory are modified.
 
     ```yaml
     watch:

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,11 @@ title: Home
 # MkDocs Data Plugin
 
 __MkDocs Data Plugin__ is a plugin for [MkDocs](https://www.mkdocs.org/) that allows
-reading data from separate external markup files and use it in your Markdown pages.
+reading data from markup files and use it in your Markdown pages.
 
 ## Overview
 When using this plugin, you can define data in YAML or JSON files
-in a separate directory and reference it in your Markdown pages.
+in a separate directory and reference them in your Markdown pages.
 
 ```txt
 root/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,8 +28,8 @@ theme:
 
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
-      primary: deep purple
-      accent: deep purple
+      primary: lime
+      accent: lime
       scheme: default 
       toggle:
         icon: material/toggle-switch
@@ -37,8 +37,8 @@ theme:
 
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
-      primary: deep purple
-      accent: deep purple
+      primary: lime
+      accent: lime
       scheme: slate
       toggle:
         icon: material/toggle-switch-off
@@ -66,7 +66,8 @@ plugins:
       use_anchor_titles: true
   - data
   - macros
-  - social
+  - social:
+      enabled: !ENV [CI, false]
   - tags
   - git-revision-date-localized
 

--- a/mkdocs_data_plugin/__init__.py
+++ b/mkdocs_data_plugin/__init__.py
@@ -1,2 +1,1 @@
-version = "0.1.0"
-__version__ = "0.1.0"
+version = "0.2.0"

--- a/mkdocs_data_plugin/plugin.py
+++ b/mkdocs_data_plugin/plugin.py
@@ -11,40 +11,40 @@ log = get_plugin_logger(__name__)
 
 
 class DataPluginConfig(base.Config):
-    mappings = c.Type(dict, default={'data': 'data'})
+    sources = c.Type(dict, default={'data': 'data'})
 
 
 class DataPlugin(BasePlugin[DataPluginConfig]):
     def __init__(self):
-        self.mappings = {}
+        self.sources = {}
         self.processors = {'.yml': yaml.safe_load, '.yaml': yaml.safe_load, '.json': json.load}
 
-    def load_mappings(self):
+    def load_sources(self):
         """
-        Load all mappings from the config file and load the data from the files.
+        Load all sources from the config file and load the data from the files.
         """
-        for mapping, path in self.config['mappings'].items():
+        for source, path in self.config['sources'].items():
             if not os.path.exists(path):
                 log.warning(f"Mapping path '{path}' not found. Skipping.")
             elif os.path.isdir(path):
-                self.load_folder(mapping, path)
+                self.load_folder(source, path)
             else:
                 value = self.load_file(path)
-                self.update_data(mapping, [], value)
+                self.update_data(source, [], value)
 
-    def update_data(self, mapping: str, keys: list, value: any):
+    def update_data(self, source: str, keys: list, value: any):
         """
-        Update the mappings data with the given value.
+        Update the sources data with the given value.
         """
         if len(keys) == 0:
-            self.mappings[mapping] = value
+            self.sources[source] = value
         else:
-            data = self.mappings.setdefault(mapping, {})
+            data = self.sources.setdefault(source, {})
             for key in keys[:-1]:
                 data = data.setdefault(key, {})
             data[keys[-1]] = value
 
-    def load_folder(self, mapping: str, path: str):
+    def load_folder(self, source: str, path: str):
         """
         Iterate over all files in the data directory
         and load them into the data attribute.
@@ -60,7 +60,7 @@ class DataPlugin(BasePlugin[DataPluginConfig]):
                 value = self.load_file(os.path.join(root, file))
 
                 filename, _ = os.path.splitext(file)
-                self.update_data(mapping, keys + [filename], value)
+                self.update_data(source, keys + [filename], value)
 
     def load_file(self, path: str):
         """
@@ -71,18 +71,18 @@ class DataPlugin(BasePlugin[DataPluginConfig]):
             return self.processors[extension](file)
 
     def on_config(self, config: MkDocsConfig):
-        self.load_mappings()
+        self.load_sources()
 
         macros_plugin = config.plugins.get('macros')
         if macros_plugin:
-            for mapping, data in self.mappings.items():
-                macros_plugin.register_variables({mapping: data})
+            for source, data in self.sources.items():
+                macros_plugin.register_variables({source: data})
         else:
             log.warning(
                 "The macros plugin is not installed. The `data` variable won't be available in pages."
             )
 
     def on_page_context(self, context, page, config, nav):
-        for mapping, data in self.mappings.items():
-            context[mapping] = data
+        for source, data in self.sources.items():
+            context[source] = data
         return context

--- a/mkdocs_data_plugin/plugin.py
+++ b/mkdocs_data_plugin/plugin.py
@@ -11,35 +11,37 @@ log = get_plugin_logger(__name__)
 
 
 class DataPluginConfig(base.Config):
-    data_dir = c.Type(str, default='data')
+    mappings = c.Type(dict, default={'data': 'data'})
 
 
 class DataPlugin(BasePlugin[DataPluginConfig]):
     def __init__(self):
-        self.data = {}
+        self.mappings = {}
         self.processors = {'.yml': yaml.safe_load, '.yaml': yaml.safe_load, '.json': json.load}
 
-    def set_data(self, keys, value):
+    def load_mappings(self):
         """
-        Set a value in the data attribute.
+        Load all mappings from the config file and load the data from the files.
         """
-        data = self.data
+        for mapping, path in self.config['mappings'].items():
+            if not os.path.exists(path):
+                log.warning(f"Mapping path '{path}' not found. Skipping.")
+            elif os.path.isdir(path):
+                self.load_folder(mapping, path)
+            else:
+                value = self.load_file(path)
+                self.set_data(mapping, [], value)
+
+    def update_data(self, mapping: str, keys: list, value: any):
+        """
+        Update the mappings data with the given value.
+        """
+        data = self.mappings.setdefault(mapping, {})
         for key in keys[:-1]:
             data = data.setdefault(key, {})
         data[keys[-1]] = value
 
-    def on_config(self, config: MkDocsConfig):
-        self.load_data(self.config.data_dir)
-
-        macros_plugin = config.plugins.get('macros')
-        if macros_plugin:
-            macros_plugin.register_variables({'data': self.data})
-        else:
-            log.warning(
-                "The macros plugin is not installed. The `data` variable won't be available in pages."
-            )
-
-    def load_data(self, path: str):
+    def load_folder(self, mapping: str, path: str):
         """
         Iterate over all files in the data directory
         and load them into the data attribute.
@@ -47,24 +49,37 @@ class DataPlugin(BasePlugin[DataPluginConfig]):
         for root, _, files in os.walk(path):
 
             keys = []
-            if root != self.config.data_dir:
-                directory = os.path.relpath(root, self.config.data_dir)
+            if root != path:
+                directory = os.path.relpath(root, path)
                 keys = directory.split(os.sep)
 
             for file in files:
                 value = self.load_file(os.path.join(root, file))
 
                 filename, _ = os.path.splitext(file)
-                self.set_data(keys + [filename], value)
+                self.update_data(mapping, keys + [filename], value)
 
     def load_file(self, path: str):
         """
-        Load a file and return its content.
+        Loads a file and processes it with the appropriate processor.
         """
         _, extension = os.path.splitext(path)
         with open(path, 'r') as file:
             return self.processors[extension](file)
 
+    def on_config(self, config: MkDocsConfig):
+        self.load_mappings()
+
+        macros_plugin = config.plugins.get('macros')
+        if macros_plugin:
+            for mapping, data in self.mappings.items():
+                macros_plugin.register_variables({mapping: data})
+        else:
+            log.warning(
+                "The macros plugin is not installed. The `data` variable won't be available in pages."
+            )
+
     def on_page_context(self, context, page, config, nav):
-        context['data'] = self.data
+        for mapping, data in self.mappings.items():
+            context[mapping] = data
         return context

--- a/mkdocs_data_plugin/plugin.py
+++ b/mkdocs_data_plugin/plugin.py
@@ -30,16 +30,19 @@ class DataPlugin(BasePlugin[DataPluginConfig]):
                 self.load_folder(mapping, path)
             else:
                 value = self.load_file(path)
-                self.set_data(mapping, [], value)
+                self.update_data(mapping, [], value)
 
     def update_data(self, mapping: str, keys: list, value: any):
         """
         Update the mappings data with the given value.
         """
-        data = self.mappings.setdefault(mapping, {})
-        for key in keys[:-1]:
-            data = data.setdefault(key, {})
-        data[keys[-1]] = value
+        if len(keys) == 0:
+            self.mappings[mapping] = value
+        else:
+            data = self.mappings.setdefault(mapping, {})
+            for key in keys[:-1]:
+                data = data.setdefault(key, {})
+            data[keys[-1]] = value
 
     def load_folder(self, mapping: str, path: str):
         """

--- a/tests/docs/fruits.yml
+++ b/tests/docs/fruits.yml
@@ -1,0 +1,3 @@
+- Apple
+- Banana
+- Strawberry

--- a/tests/docs/test_dir_source.md
+++ b/tests/docs/test_dir_source.md
@@ -1,5 +1,5 @@
 ---
-title: "Test Data Template"
+title: "Test Directory Source"
 ---
 
 - data.a: `{{ data.a }}`

--- a/tests/docs/test_file_source.md
+++ b/tests/docs/test_file_source.md
@@ -1,0 +1,7 @@
+---
+title: "Test File Source"
+---
+
+{% for fruit in fruits %}
+- `{{ fruit }}`
+{% endfor %}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,10 +6,10 @@ from mkdocs_data_plugin.plugin import DataPlugin
 def test_config_default_values():
     plugin = DataPlugin()
     plugin.load_config({})
-    assert plugin.config.data_dir == 'data'
+    assert plugin.config.mappings == {'data': 'data'}
 
 
-def test_config_data_dir():
+def test_config_mappings():
     plugin = DataPlugin()
-    plugin.load_config({'data_dir': 'other_data'})
-    assert plugin.config.data_dir == 'other_data'
+    plugin.load_config({'mappings': {'data': 'other_data'}})
+    assert plugin.config.mappings == {'data': 'other_data'}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,10 +6,10 @@ from mkdocs_data_plugin.plugin import DataPlugin
 def test_config_default_values():
     plugin = DataPlugin()
     plugin.load_config({})
-    assert plugin.config.mappings == {'data': 'data'}
+    assert plugin.config.sources == {'data': 'data'}
 
 
-def test_config_mappings():
+def test_config_sources():
     plugin = DataPlugin()
-    plugin.load_config({'mappings': {'data': 'other_data'}})
-    assert plugin.config.mappings == {'data': 'other_data'}
+    plugin.load_config({'sources': {'data': 'other_data'}})
+    assert plugin.config.sources == {'data': 'other_data'}

--- a/tests/test_data_template.py
+++ b/tests/test_data_template.py
@@ -9,7 +9,7 @@ def test_loads_files():
         "tests/mkdocs.yml",
         plugins={
             "macros": {},
-            "data": {'mappings': {'data': 'tests/data'}},
+            "data": {'sources': {'data': 'tests/data'}},
         },
     )
 

--- a/tests/test_data_template.py
+++ b/tests/test_data_template.py
@@ -4,7 +4,7 @@ from mkdocs.commands.build import build
 from mkdocs.config.base import load_config
 
 
-def test_loads_files():
+def test_dir_source_in_markdown_file():
     mkdocs_config = load_config(
         "tests/mkdocs.yml",
         plugins={
@@ -16,7 +16,7 @@ def test_loads_files():
     build(mkdocs_config)
     site_dir = mkdocs_config["site_dir"]
 
-    with open(site_dir+'/test_data_template/index.html') as f:
+    with open(site_dir+'/test_dir_source/index.html') as f:
         data_loaded = re.findall(r"<code>([^<]*)", f.read())
         print(data_loaded)
         assert(data_loaded == [
@@ -27,5 +27,26 @@ def test_loads_files():
             "text", # data/dir1/b.yml -> b2
             "3", # data/dir2/c.yml -> c1
             "text", # data/dir2/c.yml -> c2
+        ])
+
+def test_file_source_in_markdown_file():
+    mkdocs_config = load_config(
+        "tests/mkdocs.yml",
+        plugins={
+            "macros": {},
+            "data": {'sources': {'fruits': 'tests/docs/fruits.yml'}},
+        },
+    )
+
+    build(mkdocs_config)
+    site_dir = mkdocs_config["site_dir"]
+
+    with open(site_dir+'/test_file_source/index.html') as f:
+        data_loaded = re.findall(r"<code>([^<]*)", f.read())
+        print(data_loaded)
+        assert(data_loaded == [
+            "Apple",
+            "Banana",
+            "Strawberry",
         ])
 

--- a/tests/test_data_template.py
+++ b/tests/test_data_template.py
@@ -9,7 +9,7 @@ def test_loads_files():
         "tests/mkdocs.yml",
         plugins={
             "macros": {},
-            "data": {'data_dir': 'tests/data'},
+            "data": {'mappings': {'data': 'tests/data'}},
         },
     )
 

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -2,11 +2,11 @@ from mkdocs.commands.build import build
 from mkdocs.config.base import load_config
 
 
-def test_inexistent_mapping_is_skipped():
+def test_inexistent_source_is_skipped():
     mkdocs_config = load_config(
         "tests/mkdocs.yml",
         plugins={
-            "data": {'mappings': {'data': 'tests/inexistent'}}
+            "data": {'sources': {'data': 'tests/inexistent'}}
         },
     )
 
@@ -14,21 +14,21 @@ def test_inexistent_mapping_is_skipped():
 
     dataPlugin = mkdocs_config["plugins"]["data"]
 
-    assert "data" not in dataPlugin.mappings
+    assert "data" not in dataPlugin.sources
 
 
-def test_folder_mapping():
+def test_folder_source():
     mkdocs_config = load_config(
         "tests/mkdocs.yml",
         plugins={
-            "data": {'mappings': {'data': 'tests/data'}}
+            "data": {'sources': {'data': 'tests/data'}}
         },
     )
 
     build(mkdocs_config)
 
     dataPlugin = mkdocs_config["plugins"]["data"]
-    data = dataPlugin.mappings["data"]
+    data = dataPlugin.sources["data"]
 
     assert data == {
             "a": {
@@ -49,18 +49,18 @@ def test_folder_mapping():
             },
     }
 
-def test_file_mapping():
+def test_file_source():
     mkdocs_config = load_config(
         "tests/mkdocs.yml",
         plugins={
-            "data": {'mappings': {'fruits': 'tests/docs/fruits.yml'}}
+            "data": {'sources': {'fruits': 'tests/docs/fruits.yml'}}
         },
     )
 
     build(mkdocs_config)
 
     dataPlugin = mkdocs_config["plugins"]["data"]
-    data = dataPlugin.mappings["fruits"]
-    print(dataPlugin.mappings)
+    data = dataPlugin.sources["fruits"]
+    print(dataPlugin.sources)
 
     assert data == ['Apple', 'Banana', 'Strawberry']

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -49,6 +49,38 @@ def test_folder_source():
             },
     }
 
+def test_folder_source_slash():
+    mkdocs_config = load_config(
+        "tests/mkdocs.yml",
+        plugins={
+            "data": {'sources': {'data': 'tests/data/'}}
+        },
+    )
+
+    build(mkdocs_config)
+
+    dataPlugin = mkdocs_config["plugins"]["data"]
+    data = dataPlugin.sources["data"]
+
+    assert data == {
+            "a": {
+                "a1": 1,
+                "a2": "text",
+            },
+            "dir1": {
+                "b": {
+                    "b1": 2,
+                    "b2": "text",
+                },
+            },
+            "dir2": {
+                "c": {
+                    "c1": 3,
+                    "c2": "text",
+                },
+            },
+    }
+
 def test_file_source():
     mkdocs_config = load_config(
         "tests/mkdocs.yml",

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -2,34 +2,33 @@ from mkdocs.commands.build import build
 from mkdocs.config.base import load_config
 
 
-def test_empty_data_is_empty_dict():
+def test_inexistent_mapping_is_skipped():
     mkdocs_config = load_config(
         "tests/mkdocs.yml",
         plugins={
-            "data": {'data_dir': 'tests/inexistent'}
+            "data": {'mappings': {'data': 'tests/inexistent'}}
         },
     )
 
     build(mkdocs_config)
 
     dataPlugin = mkdocs_config["plugins"]["data"]
-    data = dataPlugin.data
 
-    assert data == {}
+    assert "data" not in dataPlugin.mappings
 
 
-def test_loads_files():
+def test_folder_mapping():
     mkdocs_config = load_config(
         "tests/mkdocs.yml",
         plugins={
-            "data": {'data_dir': 'tests/data'}
+            "data": {'mappings': {'data': 'tests/data'}}
         },
     )
 
     build(mkdocs_config)
 
     dataPlugin = mkdocs_config["plugins"]["data"]
-    data = dataPlugin.data
+    data = dataPlugin.mappings["data"]
 
     assert data == {
             "a": {

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -48,3 +48,19 @@ def test_folder_mapping():
                 },
             },
     }
+
+def test_file_mapping():
+    mkdocs_config = load_config(
+        "tests/mkdocs.yml",
+        plugins={
+            "data": {'mappings': {'fruits': 'tests/docs/fruits.yml'}}
+        },
+    )
+
+    build(mkdocs_config)
+
+    dataPlugin = mkdocs_config["plugins"]["data"]
+    data = dataPlugin.mappings["fruits"]
+    print(dataPlugin.mappings)
+
+    assert data == ['Apple', 'Banana', 'Strawberry']


### PR DESCRIPTION
Allow multiple file sources with the option `sources`, instead of `data_dir`.

```yml
plugins:
  sources:
    data: data/
    fruits: docs/fruits.yml
```